### PR TITLE
Restructuring, factorising common functionality and reusing existing Rocq functions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ Fixpoint add (a b : nat) : nat :=
     | S a => S (add a b)
   end.
 
-MetaCoq Run (ensure_tail_recursion add).
+MetaRocq Run (ensure_tail_recursion add).
 ```
 
 The output should be something like:

--- a/rocq-trchecker.opam
+++ b/rocq-trchecker.opam
@@ -19,9 +19,9 @@ depends: [
 ]
 synopsis: "Implementation of a tail recursiveness check for Rocq"
 description: """
-MetaCoq is a meta-programming framework for Rocq.
+MetaRocq is a meta-programming framework for Rocq.
 
-This module uses the MetaCoq infrastructure and contains functions that
+This module uses the MetaRocq infrastructure and contains functions that
 check whether a specific Rocq function and all functions being called
 transitively are tail-recursive.
 """

--- a/theories/Commands.v
+++ b/theories/Commands.v
@@ -30,8 +30,9 @@ Definition ensure_tail_recursion {A} (t : A) : TemplateMonad unit :=
   
   let fprs := find_all_rec_references_global d in
   monad_iter (fun fpr => tmMsg (string_of_FixpointReference fpr)) fprs ;;
-  let alltailcall := forallb (fun fpr => if fpr.(kind) is Tailcall then true else false) fprs in
-  (if alltailcall then tmMsg "Program contains only Tail-recursive calls." else tmFail "Program contains Non-Tail-recursive calls.") ;;
+  (if all_tailcalls fprs
+   then tmMsg "Program contains only Tail-recursive calls."
+   else tmFail "Program contains Non-Tail-recursive calls.") ;;
   ret tt.
 
 (** Extracts the definition of every transparent constant in the list of global references from the current environment.
@@ -59,6 +60,9 @@ Definition check_tail_recursion_in_module (q: string) : TemplateMonad unit :=
   d <- get_all_definitions_from_references grs ;;
   let fprs := flat_map (fun '(kn, t) => find_all_rec_references t kn) d in
   monad_iter (fun fpr => tmMsg (string_of_FixpointReference fpr)) fprs ;;
-  let alltailcall := forallb (fun fpr => if fpr.(kind) is Tailcall then true else false) fprs in
-  (if alltailcall then tmMsg "Module contains only Tail-recursive calls." else tmMsg "Module contains Non-Tail-recursive calls.") ;;
+  (let msg := if all_tailcalls fprs
+     then "Module contains only Tail-recursive calls."
+     else "Module contains Non-Tail-recursive calls."
+   in tmMsg msg
+  ) ;;
   ret tt.

--- a/theories/ContextTracking.v
+++ b/theories/ContextTracking.v
@@ -4,7 +4,7 @@ From MetaRocq.Template Require Import All.
 (* This file contains the basic definitions Context Tracking.
 It is only used internally in TailRecursionDetection.v. *)
 
-(* All relevant fixpoints in the current context are kept track of in a list of pairs of deBrujin indices and names.
+(* All relevant fixpoints in the current context are kept track of in a list of pairs of de Bruijn indices and names.
 When the context changes, these indices need to be updated accordingly. *)
 
 Definition fixpointcontext := list (nat * name).
@@ -20,8 +20,5 @@ Definition increase_context (cur : fixpointcontext) (b : nat) : fixpointcontext 
 
 (** If the specified [index] corresponds to a fixpoint in the current context, return it's name.
 Otherwise return [None]. *)
-Fixpoint get_name_from_context (context : fixpointcontext) (index : nat) : option name :=
-  match context with
-  | [] => None
-  | (i,n)::c => if i =? index then Some n else get_name_from_context c index
-  end.
+Definition get_name_from_context (context : fixpointcontext) (index : nat) : option name :=
+  SetoidList.findA (fun i => i =? index) context.

--- a/theories/FixpointReference.v
+++ b/theories/FixpointReference.v
@@ -1,6 +1,8 @@
 From MetaRocq.Utils Require Import utils.
 From MetaRocq.Template Require Import All.
 
+Import IfNotations.
+
 (* This file contains the basic definitions of [FixpointReference].
 These are mainly produced in TailRecursionDetection.v and used in Commands.v. *)
 
@@ -21,6 +23,17 @@ Record FixpointReference := mkFixpointReference {
   callterm : term;
   kind : FixpointReferenceKind;
 }.
+
+
+(** Returns [true], iff the fixpoint reference is a [Tailcall].*)
+Definition is_tailcall (fpr : FixpointReference) :=
+  if fpr.(kind) is Tailcall then true else false.
+
+
+(** Returns [true], iff all fixpoint references are [Tailcall]s.*)
+Definition all_tailcalls (fprs : list FixpointReference) :=
+  forallb (fun fpr => is_tailcall fpr) fprs.
+
 
 Definition string_of_FixpointReference (fpr : FixpointReference) : string :=
   match fpr.(kind) with

--- a/theories/TailRecursionDetection.v
+++ b/theories/TailRecursionDetection.v
@@ -34,7 +34,7 @@ Fixpoint strip_lambdas (t : term) : (nat * term) :=
 (** Takes a term (typically a function body) and a list of indices and names and returns a list of all references to these indices.
 [caller] and [definition] are used to create the reference record. *)
 Definition find_all_references (t : term) (context : fixpointcontext) (caller : name) (definition : kername) : list FixpointReference :=
-  (** Recursively descend into a term and return a list of all references with matching deBrujin indices.
+  (** Recursively descend into a term and return a list of all references with matching de Bruijn indices.
   (For example recursive function calls.)
   [context] is automatically adjusted during the function call to handle newly introduced variables.
   [is_tailpos] denotes if the current term is in tail positiion. This is used to either assign Tailcall or NonTailcall as a reference [kind]. *)
@@ -44,7 +44,7 @@ Definition find_all_references (t : term) (context : fixpointcontext) (caller : 
     
     (* Function Application *)
     | tApp func args => (flat_map find_all_references_aux_notail args) ++
-      (* Check for direct function call with matching deBrujin index. *)
+      (* Check for direct function call with matching de Bruijn index. *)
       if func is (tRel n)
         then if (get_name_from_context context n) is Some callee
           (* Matching function call -> create reference *)
@@ -54,7 +54,7 @@ Definition find_all_references (t : term) (context : fixpointcontext) (caller : 
         (* No direct function call -> descend into function. *)
         else find_all_references_aux_notail func
     
-    (* Let Expressions: increase deBruj in index by 1 *) 
+    (* Let Expressions: increase de Bruijn index by 1 *)
     | tLetIn _name def _type body => find_all_references_aux_notail def ++ find_all_references_aux body (increase_context context 1) is_tailpos
     
     (* Pattern Matching and Projection *)


### PR DESCRIPTION
I factorised out the check whether a fixpoint reference has kind tail recursive and also the check on a list of fixpoint references. Also, `get_name_from_context` is indeed the same as `SetoidList.findA`, so we can reuse that.

Apart from that I removed some rudiments from the "Coq" era and fixed the use of the term `de Bruijn`

Fixes #2 